### PR TITLE
Add zsh autocompletion definition

### DIFF
--- a/autocompletion/zsh/warden.plugin.zsh
+++ b/autocompletion/zsh/warden.plugin.zsh
@@ -1,0 +1,20 @@
+#compdef warden
+
+# Installation
+# ============
+#
+# Copy this file, `warden.plugin.zsh`, to `~/.oh-my-zsh/plugins/custom/warden/`
+#
+# Enable the plugin by adding `warden` to `plugins=(… warden)` in `~/.zshrc`
+#
+# Reload your zsh session, or source `~/.zshrc`
+
+_warden_get_command_list() {
+    warden | sed -n '/Commands:/,$p' | sed '1d' | awk '{print $1}'
+}
+
+_warden() {
+    compadd `_warden_get_command_list`
+}
+
+compdef _warden warden

--- a/commands/blackfire.cmd
+++ b/commands/blackfire.cmd
@@ -4,7 +4,7 @@
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 
-## set defaults for this command which can be overriden either using exports in the user
+## set defaults for this command which can be overridden either using exports in the user
 ## profile or setting them in the .env configuration on a per-project basis
 WARDEN_ENV_BLACKFIRE_COMMAND=${WARDEN_ENV_BLACKFIRE_COMMAND:-blackfire}
 WARDEN_ENV_BLACKFIRE_CONTAINER=${WARDEN_ENV_BLACKFIRE_CONTAINER:-php-blackfire}

--- a/commands/usage.help
+++ b/commands/usage.help
@@ -2,11 +2,11 @@
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
 WARDEN_HEADER='
- _       __               __         
-| |     / /___ __________/ /__  ____ 
+ _       __               __
+| |     / /___ __________/ /__  ____
 | | /| / / __ `/ ___/ __  / _ \/ __ \
 | |/ |/ / /_/ / /  / /_/ /  __/ / / /
-|__/|__/\__,_/_/   \__,_/\___/_/ /_/ 
+|__/|__/\__,_/_/   \__,_/\___/_/ /_/
 '
 
 WARDEN_USAGE=$(cat <<EOF
@@ -28,6 +28,8 @@ Warden version $(cat ${WARDEN_DIR}/version)
   shell             Launches into a shell within the current project environment
   debug             Launches debug enabled shell within current project environment
   sign-certificate  Signs a wildcard certificate including all passed hostnames on the SAN list
+  sync              Controls the mutagen session (if using mutagen; see 'warden sync -h' for details)
+  vnc               Establishes vnc sessions (see 'warden vnc -h' for details)
   version           Show version information
 EOF
 )


### PR DESCRIPTION
This PR adds an autocompletion definition script for zsh that uses sed and awk to parse the output of `usage.help`.

It also adds `sync` and `vnc` to the `usage.help` file, and corrects a typo.