### PR TITLE
Ignore the only root .git directory

### DIFF
--- a/environments/magento2/magento2.mutagen.yml
+++ b/environments/magento2/magento2.mutagen.yml
@@ -5,8 +5,11 @@ sync:
     watch:
       pollingInterval: 10
     ignore:
-      vcs: true
+      vcs: false
       paths:
+        # Root .git folder 
+        - "/.git/"
+      
         # System files
         - ".DS_Store"
         - "._*"


### PR DESCRIPTION
While working with m2 projects, it's quite a frequent case when you have a separate git repository per extension, so while developing something you're installing a module from a branch, do your changes directly in vendor/<vendor_name>/<module_name> and then do commits directly from this. Such flow helps significantly reduce time on installing each new version via composer.

The issue with Warden in such configuration is that ALL .git folders are ignored in the mutagen config. As a result - on Mac OS, you can't see the diff, commit changes, etc. (the .git directory is entirely missing in the module folder) 

My PR changes this behavior by ignoring the only root directory git repo.