### PR TITLE
Rootless podman support

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -18,6 +18,8 @@ if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
 fi
 export WARDEN_IMAGE_REPOSITORY="${WARDEN_IMAGE_REPOSITORY:-"docker.io/wardenenv"}"
 
+export WARDEN_DOCKER_USERNS_MODE="${WARDEN_DOCKER_USERNS_MODE:-host}"
+
 ## configure environment type defaults
 if [[ ${WARDEN_ENV_TYPE} =~ ^magento ]]; then
     export WARDEN_SVC_PHP_VARIANT=-${WARDEN_ENV_TYPE}

--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -23,7 +23,11 @@ if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
     eval "$(grep "^WARDEN_DNSMASQ_ENABLE" "${WARDEN_HOME_DIR}/.env")"
     # Check Portainer
     eval "$(grep "^WARDEN_PORTAINER_ENABLE" "${WARDEN_HOME_DIR}/.env")"
+    # Check Docker socket
+    eval "$(grep "^WARDEN_DOCKER_SOCK" "${WARDEN_HOME_DIR}/.env")"
 fi
+
+export WARDEN_DOCKER_SOCK="${WARDEN_DOCKER_SOCK:-/var/run/docker.sock}"
 
 ## add dnsmasq docker-compose
 WARDEN_DNSMASQ_ENABLE="${WARDEN_DNSMASQ_ENABLE:-1}"

--- a/docker/docker-compose.portainer.yml
+++ b/docker/docker-compose.portainer.yml
@@ -4,7 +4,7 @@ services:
     container_name: portainer
     image: portainer/portainer-ce
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${WARDEN_DOCKER_SOCK}:/var/run/docker.sock
       - portainer:/data
     labels:
       - traefik.enable=true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ${WARDEN_HOME_DIR}/etc/traefik/traefik.yml:/etc/traefik/traefik.yml
       - ${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml:/etc/traefik/dynamic.yml
       - ${WARDEN_HOME_DIR}/ssl/certs:/etc/ssl/certs
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${WARDEN_DOCKER_SOCK}:/var/run/docker.sock
     labels:
       - traefik.enable=true
       - traefik.http.routers.traefik.tls=true

--- a/environments/includes/php-fpm.base.yml
+++ b/environments/includes/php-fpm.base.yml
@@ -30,6 +30,7 @@ services:
       - CHOWN_DIR_LIST=${CHOWN_DIR_LIST:-}
     volumes: *volumes
     extra_hosts: *extra_hosts
+    userns_mode: ${WARDEN_DOCKER_USERNS_MODE:-host}
 
   php-debug:
     hostname: "${WARDEN_ENV_NAME}-php-debug"
@@ -46,6 +47,7 @@ services:
       - CHOWN_DIR_LIST=${CHOWN_DIR_LIST:-}
     volumes: *volumes
     extra_hosts: *extra_hosts
+    userns_mode: ${WARDEN_DOCKER_USERNS_MODE:-host}
     depends_on:
       - php-fpm
 volumes:


### PR DESCRIPTION
I like using Podman. It's easy to use and deploy, has proper rootless support and is also compatible with Docker and Docker Compose.

To get Warden working with Podman on my Fedora 37 machine (with SELinux disabled), I had to make a few changes:
- Build the php-fpm/magento2 image locally (looks like it has something to do with some bad UIDs in `node_modules`)
  ```console
  $ warden env pull
  ...
  copying system image from manifest list: writing blob: adding layer with blob 
  "sha256:30a0e4949fbc3d1e962886ce598ed231fda3429c79ba6ef20136d5c83664941e": processing tar 
  file(potentially insufficient UIDs or GIDs available in user namespace (requested 376884:5762 for 
  /usr/local/lib/node_modules/gulp/node_modules/clone-stats/LICENSE.md): Check /etc/subuid and 
  /etc/subgid if configured locally and run podman-system-migrate: lchown 
  /usr/local/lib/node_modules/gulp/node_modules/clone-stats/LICENSE.md: invalid argument): exit status 1
  ```
- Change and build the nginx image to check the common Podman resolver IP, including setting a resolver_timeout (need to create a PR for the images repo).
- Disable Warden dnsmasq (I use NetworkManager dnsmasq)
  ```bash
  echo -e "[main]\ndns=dnsmasq" > /etc/NetworkManager/conf.d/00-use-dnsmasq.conf
  echo -e "no-resolv\n\nbind-interfaces\n\nserver=1.1.1.1\nserver=1.0.0.1\n\nstrict-order\n\naddress=/.test/127.0.0.1" > /etc/NetworkManager/dnsmasq.d/warden.conf
  ```
- Allow unprivileged user to bind to port 80 and higher
  ```bash
  echo net.ipv4.ip_unprivileged_port_start=80 | sudo tee /etc/sysctl.d/99-warden.conf
  sudo sysctl --system
  ```
- Set following Warden settings, related to this PR
  ```bash
  echo 'WARDEN_DNSMASQ_ENABLE=0' >> ~/.warden/.env
  echo 'WARDEN_DOCKER_SOCK=${XDG_RUNTIME_DIR}/podman/podman.sock' >> ~/.warden/.env
  echo 'WARDEN_DOCKER_USERNS_MODE=keep-id' >> ~/.warden/.env
  ```