### PR TITLE
Fix Mutagen always resyncing when running `warden env up`

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -201,18 +201,24 @@ if ([[ "${WARDEN_PARAMS[0]}" == "up" ]] || [[ "${WARDEN_PARAMS[0]}" == "start" ]
     && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${MUTAGEN_SYNC_FILE}" ]] \
     && [[ $($WARDEN_BIN sync list | grep -i 'Status: \[Paused\]' | wc -l | awk '{print $1}') == "1" ]] \
     && [[ $($WARDEN_BIN env ps -q php-fpm) ]] \
-    && [[ $(docker container inspect $($WARDEN_BIN env ps -q php-fpm) --format '{{ .State.Status }}') = "running" ]] \
+    && [[ $(docker container inspect "$($WARDEN_BIN env ps -q php-fpm)" --format '{{ .State.Status }}') = "running" ]] \
     && [[ $($WARDEN_BIN env ps -q php-fpm) = $($WARDEN_BIN sync list | grep -i 'URL: docker' | awk -F'/' '{print $3}') ]]
 then
     $WARDEN_BIN sync resume
 fi
 
+MUTAGEN_VERSION=$(mutagen version)
+CONNECTION_STATE_STRING='Connected state: Connected'
+if [[ $(version "${MUTAGEN_VERSION}") -ge $(version '0.15.0') ]]; then
+  CONNECTION_STATE_STRING='Connected: Yes'
+fi
+
 ## start mutagen sync if needed
 if ([[ "${WARDEN_PARAMS[0]}" == "up" ]] || [[ "${WARDEN_PARAMS[0]}" == "start" ]]) \
     && [[ $OSTYPE =~ ^darwin ]] && [[ -f "${MUTAGEN_SYNC_FILE}" ]] \
-    && [[ $($WARDEN_BIN sync list | grep -i 'Connection state: Connected' | wc -l | awk '{print $1}') != "2" ]] \
+    && [[ $($WARDEN_BIN sync list | grep -c "${CONNECTION_STATE_STRING}" | awk '{print $1}') != "2" ]] \
     && [[ $($WARDEN_BIN env ps -q php-fpm) ]] \
-    && [[ $(docker container inspect $($WARDEN_BIN env ps -q php-fpm) --format '{{ .State.Status }}') = "running" ]]
+    && [[ $(docker container inspect "$($WARDEN_BIN env ps -q php-fpm)" --format '{{ .State.Status }}') = "running" ]]
 then
     $WARDEN_BIN sync start
 fi


### PR DESCRIPTION
As of Mutagen 0.15.0, It displays "Connected: Yes" for beta and alpha if they are connected

I have not been able to identify where "Connected state: Connected" used to be as of yet, but I'm making the assumption it changed to "Connected:" when it first appears in list_monitor_common.go, which is v0.15.0.

Prior to this commit, Warden would always run `warden sync start` after `warden env up` - which for larger projects on machines with Antivirus is.. incredibly annoying.