### PR TITLE
Fixes broken linux warden builds on 0.14 version related to issue #672 

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -207,7 +207,7 @@ then
     $WARDEN_BIN sync resume
 fi
 
-MUTAGEN_VERSION=$(command -v mutagen && mutagen version)
+MUTAGEN_VERSION=$(command -v mutagen > /dev/null && mutagen version)
 CONNECTION_STATE_STRING='Connected state: Connected'
 if [[ $(version "${MUTAGEN_VERSION}") -ge $(version '0.15.0') ]]; then
   CONNECTION_STATE_STRING='Connected: Yes'

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -207,7 +207,7 @@ then
     $WARDEN_BIN sync resume
 fi
 
-MUTAGEN_VERSION=$(mutagen version)
+MUTAGEN_VERSION=$(command -v mutagen && mutagen version)
 CONNECTION_STATE_STRING='Connected state: Connected'
 if [[ $(version "${MUTAGEN_VERSION}") -ge $(version '0.15.0') ]]; then
   CONNECTION_STATE_STRING='Connected: Yes'


### PR DESCRIPTION
This pull request fixes #672, which prevents running warden in clean Linux environment. 

This PR adds quick check to if command exists before running it to make sure it won't error out on system where mutagen is not needed.