### PR TITLE
#115: linux permissions

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -4,8 +4,8 @@
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 assertDockerRunning
-HOSTUID=$(id -u)
-HOSTGID=$(id -g)
+HOST_UID=$(id -u)
+HOST_GID=$(id -g)
 
 if (( ${#WARDEN_PARAMS[@]} == 0 )) || [[ "${WARDEN_PARAMS[0]}" == "help" ]]; then
   # shellcheck disable=SC2153
@@ -231,14 +231,14 @@ then
 fi
 
 if [[ "${WARDEN_PARAMS[0]}" == "up" ]] || [[ "${WARDEN_PARAMS[0]}" == "start" ]]; then
-    if [[ $($WARDEN_BIN env ps -q php-fpm) ]] && [ $($WARDEN_BIN env exec php-fpm "id" "-u" "www-data") != ${HOSTUID} ]; then
-        $WARDEN_BIN env exec -u 0 php-fpm "usermod" "-u" "${HOSTUID}" "www-data"
-        $WARDEN_BIN env exec -u 0 php-fpm "usermod" "-g" "${HOSTGID}" "www-data"
+    if [[ $($WARDEN_BIN env ps -q php-fpm) ]] && [ $($WARDEN_BIN env exec php-fpm "id" "-u" "www-data") != ${HOST_UID} ]; then
+        $WARDEN_BIN env exec -u 0 php-fpm "usermod" "-u" "${HOST_UID}" "www-data"
+        $WARDEN_BIN env exec -u 0 php-fpm "usermod" "-g" "${HOST_GID}" "www-data"
         $WARDEN_BIN env restart php-fpm
     fi
-    if [[ $($WARDEN_BIN env ps -q php-debug) ]] && [ $($WARDEN_BIN env exec php-debug "id" "-u" "www-data") != ${HOSTUID} ]; then
-        $WARDEN_BIN env exec -u 0 php-debug "usermod" "-u" "${HOSTUID}" "www-data"
-        $WARDEN_BIN env exec -u 0 php-debug "usermod" "-g" "${HOSTGID}" "www-data"
+    if [[ $($WARDEN_BIN env ps -q php-debug) ]] && [ $($WARDEN_BIN env exec php-debug "id" "-u" "www-data") != ${HOST_UID} ]; then
+        $WARDEN_BIN env exec -u 0 php-debug "usermod" "-u" "${HOST_UID}" "www-data"
+        $WARDEN_BIN env exec -u 0 php-debug "usermod" "-g" "${HOST_GID}" "www-data"
         $WARDEN_BIN env restart php-debug
     fi
 fi

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -4,6 +4,8 @@
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 assertDockerRunning
+HOSTUID=$(id -u)
+HOSTGID=$(id -g)
 
 if (( ${#WARDEN_PARAMS[@]} == 0 )) || [[ "${WARDEN_PARAMS[0]}" == "help" ]]; then
   # shellcheck disable=SC2153
@@ -226,6 +228,19 @@ then
   then
       $WARDEN_BIN sync start
   fi
+fi
+
+if [[ "${WARDEN_PARAMS[0]}" == "up" ]] || [[ "${WARDEN_PARAMS[0]}" == "start" ]]; then
+    if [[ $($WARDEN_BIN env ps -q php-fpm) ]] && [ $($WARDEN_BIN env exec php-fpm "id" "-u" "www-data") != ${HOSTUID} ]; then
+        $WARDEN_BIN env exec -u 0 php-fpm "usermod" "-u" "${HOSTUID}" "www-data"
+        $WARDEN_BIN env exec -u 0 php-fpm "usermod" "-g" "${HOSTGID}" "www-data"
+        $WARDEN_BIN env restart php-fpm
+    fi
+    if [[ $($WARDEN_BIN env ps -q php-debug) ]] && [ $($WARDEN_BIN env exec php-debug "id" "-u" "www-data") != ${HOSTUID} ]; then
+        $WARDEN_BIN env exec -u 0 php-debug "usermod" "-u" "${HOSTUID}" "www-data"
+        $WARDEN_BIN env exec -u 0 php-debug "usermod" "-g" "${HOSTGID}" "www-data"
+        $WARDEN_BIN env restart php-debug
+    fi
 fi
 
 ## stop mutagen sync if needed


### PR DESCRIPTION
@navarr this is mainly a kickoff

To cleanly set a gid and uid, this should happen on build time.
Since images are build in advance, this is not possible.
Adding an entrypoint in docker-compose was not clean enough either in my opinion, hence checking in the project for php-fpm and php-debug, fixing the user and restarting the container.