### PR TITLE
fix: Indenting on Traefik default certificate

### DIFF
--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -66,9 +66,9 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
 		tls:
 		  stores:
 		    default:
-		    defaultCertificate:
-		      certFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.crt.pem
-		      keyFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.key.pem
+		      defaultCertificate:
+		        certFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.crt.pem
+		        keyFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.key.pem
 		  certificates:
 	EOT
 


### PR DESCRIPTION
Fix default Traefik cert indentation as per Traefik docs. https://doc.traefik.io/traefik/https/tls/#default-certificate

fixes: #724 