### PR TITLE
Opensearch - Fix incorrect java options env variable

### DIFF
--- a/environments/includes/opensearch.base.yml
+++ b/environments/includes/opensearch.base.yml
@@ -12,7 +12,7 @@ services:
     environment:
       - DISABLE_SECURITY_PLUGIN=true
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms64m -Xmx512m"
+      - "OPENSEARCH_JAVA_OPTS=-Xms64m -Xmx512m"
     volumes:
       - osdata:/usr/share/opensearch/data
 


### PR DESCRIPTION
I had an issue when opensearch container was stopping with message like this for some reason:
```
2024-01-11 19:16:21 ./opensearch-docker-entrypoint.sh: line 70:   108 Killed                  "$@" "${opensearch_opts[@]}"
```
or 
```
2024-01-11 19:18:47 ./opensearch-docker-entrypoint.sh: line 70:    34 Killed                  "$@" "${opensearch_opts[@]}"
```

I looked what could potentially cause such issue and found that opensearch should actually have a different env variable for configuring memory params in JVM, not `ES_JAVA_OPTS` (from ElasticSearch), but `OPENSEARCH_JAVA_OPTS`:
https://opensearch.org/docs/1.0/opensearch/install/important-settings/

After fixing path, looks like the opensearch works fine