### PR TITLE
linux permissions - env side

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -5,6 +5,9 @@ WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 assertDockerRunning
 
+HOST_UID=$(id -u)
+HOST_GID=$(id -g)
+
 if (( ${#WARDEN_PARAMS[@]} == 0 )) || [[ "${WARDEN_PARAMS[0]}" == "help" ]]; then
   # shellcheck disable=SC2153
   $WARDEN_BIN env --help || exit $? && exit $?


### PR DESCRIPTION
This PR is to prepare for adding linux permissions in the images repo.
It will provide the uid and gid on every env command.

When adding `HOST_UID` and `HOST_GID` to the user part in docker-compose

```
    user: "${HOST_UID}:${HOST_GID}"
```

Docker will expect these on every cmd.

The PR does not interfere with any current functionality.