### PR TITLE
Fix [Command] warden env start #739, services.nginx.labels array item…

### DIFF
--- a/environments/includes/varnish.base.yml
+++ b/environments/includes/varnish.base.yml
@@ -3,9 +3,8 @@ services:
   nginx:
     labels:
       - traefik.enable=false
-      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.priority=2
-      - traefik.docker.network=${WARDEN_ENV_NAME}_default
-
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.priority="2"
+      - traefik.docker.network="${WARDEN_ENV_NAME}_default"
   varnish:
     hostname: "${WARDEN_ENV_NAME}-varnish"
     image: ${WARDEN_IMAGE_REPOSITORY}/varnish:${VARNISH_VERSION:-6.0}


### PR DESCRIPTION
Fix Issue: https://github.com/wardenenv/warden/issues/739

`$ warden env start
validating /opt/warden/environments/includes/varnish.base.yml: services.nginx.labels array items[2,7] must be unique`