### PR TITLE
Optional Mutagen

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -19,6 +19,11 @@ trap '' ERR
 ## define source repository
 if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
   eval "$(sed 's/\r$//g' < "${WARDEN_HOME_DIR}/.env" | grep "^WARDEN_")"
+
+  ## Temporary fix to force mutagen activation
+  if [[ ${WARDEN_MUTAGEN_ENABLE} == '' ]]; then
+    export WARDEN_MUTAGEN_ENABLE=1
+  fi
 fi
 export WARDEN_IMAGE_REPOSITORY="${WARDEN_IMAGE_REPOSITORY:-"docker.io/wardenenv"}"
 
@@ -174,7 +179,10 @@ TRAEFIK_ADDRESS="$(docker container inspect traefik \
 )"
 export TRAEFIK_ADDRESS;
 
-if [[ $OSTYPE =~ ^darwin ]]; then
+if [[ $OSTYPE =~ ^darwin ]] && [[ ${WARDEN_MUTAGEN_ENABLE} -eq 1 ]]; then
+    echo -e "\033[31mMutagen is being deprecated!!\033[0m"
+    echo -e "\033[31mTo disable it, add WARDEN_MUTAGEN_ENABLE=0 in ~/.warden/.env file\033[0m"
+
     export MUTAGEN_SYNC_FILE="${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml"
 
     if [[ -f "${WARDEN_HOME_DIR}/environments/${WARDEN_ENV_TYPE}/${WARDEN_ENV_TYPE}.mutagen.yml" ]]; then

--- a/commands/install.cmd
+++ b/commands/install.cmd
@@ -93,5 +93,7 @@ if [[ ! -f "${WARDEN_HOME_DIR}/.env" ]]; then
 		WARDEN_PORTAINER_ENABLE=0
 		# SEt to "0" to disable DNSMasq
 		WARDEN_DNSMASQ_ENABLE=1
+        # Set to "1" to enable Mutagen
+        WARDEN_MUTAGEN_ENABLE=1
 	EOT
 fi

--- a/utils/env.sh
+++ b/utils/env.sh
@@ -53,6 +53,10 @@ function loadEnvConfig () {
         ;;
     esac
 
+    if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+      eval "$(sed 's/\r$//g' < "${WARDEN_HOME_DIR}/.env" | grep "^WARDEN_")"
+    fi
+
     assertValidEnvType
 }
 
@@ -122,18 +126,28 @@ function appendEnvPartialIfExists () {
         "${WARDEN_DIR}/environments/includes/${PARTIAL_NAME}.base.yml" \
         "${WARDEN_DIR}/environments/includes/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
         "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.base.yml" \
-        "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
         "${WARDEN_HOME_DIR}/environments/includes/${PARTIAL_NAME}.base.yml" \
         "${WARDEN_HOME_DIR}/environments/includes/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
         "${WARDEN_HOME_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.base.yml" \
-        "${WARDEN_HOME_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
         "${WARDEN_ENV_PATH}/.warden/environments/includes/${PARTIAL_NAME}.base.yml" \
         "${WARDEN_ENV_PATH}/.warden/environments/includes/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
-        "${WARDEN_ENV_PATH}/.warden/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.base.yml" \
-        "${WARDEN_ENV_PATH}/.warden/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml"
+        "${WARDEN_ENV_PATH}/.warden/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.base.yml"
     do
         if [[ -f "${PARTIAL_PATH}" ]]; then
             DOCKER_COMPOSE_ARGS+=("-f" "${PARTIAL_PATH}")
         fi
     done
+
+    if [[ "${WARDEN_ENV_SUBT}" == "darwin" ]] && [[ "${WARDEN_MUTAGEN_ENABLE}" == "1" ]]; then
+        for PARTIAL_PATH in \
+        "${WARDEN_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
+        "${WARDEN_HOME_DIR}/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml" \
+        "${WARDEN_ENV_PATH}/.warden/environments/${WARDEN_ENV_TYPE}/${PARTIAL_NAME}.${WARDEN_ENV_SUBT}.yml"
+        do
+            if [[ -f "${PARTIAL_PATH}" ]]; then
+                DOCKER_COMPOSE_ARGS+=("-f" "${PARTIAL_PATH}")
+            fi
+        done
+    fi;
+
 }


### PR DESCRIPTION
This change allows you to activate or deactivate **Mutagen** from the warden configuration `.env` file with `WARDEN_MUTAGEN_ENABLE=0`.
By default, Mutagen is active.
A message is also painted indicating that Mutagen is being deprecated.