### PR TITLE
Implement Sablier Traefik Plugin for Workload Management

### DIFF
--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -125,6 +125,13 @@ fi
 [[ ${WARDEN_MAGEPACK} -eq 1 ]] \
     && appendEnvPartialIfExists "${WARDEN_ENV_TYPE}.magepack"
 
+if [[ ${WARDEN_SABLIER_ENABLE:-0} -eq 1 ]]; then
+    appendEnvPartialIfExists "sablier"
+    
+    [[ ${WARDEN_VARNISH} -eq 1 ]] \
+        && appendEnvPartialIfExists "sablier-varnish"
+fi
+
 if [[ -f "${WARDEN_ENV_PATH}/.warden/warden-env.yml" ]]; then
     DOCKER_COMPOSE_ARGS+=("-f")
     DOCKER_COMPOSE_ARGS+=("${WARDEN_ENV_PATH}/.warden/warden-env.yml")

--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -23,6 +23,8 @@ if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
     eval "$(grep "^WARDEN_DNSMASQ_ENABLE" "${WARDEN_HOME_DIR}/.env")"
     # Check Portainer
     eval "$(grep "^WARDEN_PORTAINER_ENABLE" "${WARDEN_HOME_DIR}/.env")"
+    # Check Sablier
+    eval "$(grep "^WARDEN_SABLIER_ENABLE" "${WARDEN_HOME_DIR}/.env")"
 fi
 
 ## add dnsmasq docker-compose
@@ -36,6 +38,12 @@ WARDEN_PORTAINER_ENABLE="${WARDEN_PORTAINER_ENABLE:-0}"
 if [[ "${WARDEN_PORTAINER_ENABLE}" == 1 ]]; then
     DOCKER_COMPOSE_ARGS+=("-f")
     DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/docker/docker-compose.portainer.yml")
+fi
+
+WARDEN_SABLIER_ENABLE="${WARDEN_SABLIER_ENABLE:-0}"
+if [[ "$WARDEN_SABLIER_ENABLE" == "1" ]]; then
+    DOCKER_COMPOSE_ARGS+=("-f")
+    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/docker/docker-compose.sablier.yml")
 fi
 
 ## allow an additional docker-compose file to be loaded for global services
@@ -61,21 +69,28 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
     mkdir -p "${WARDEN_HOME_DIR}/etc/traefik"
     cp "${WARDEN_DIR}/config/traefik/traefik.yml" "${WARDEN_HOME_DIR}/etc/traefik/traefik.yml"
 
+    ## copy sablier configuration files into location where they'll be mounted into containers from
+    if [[ "$WARDEN_SABLIER_ENABLE" == "1" ]]; then
+        mkdir -p "${WARDEN_HOME_DIR}/etc/sablier/theme"
+        cp "${WARDEN_DIR}/config/sablier/sablier.yml" "${WARDEN_HOME_DIR}/etc/sablier/sablier.yml"
+        cp "${WARDEN_DIR}/config/sablier/theme/warden.html" "${WARDEN_HOME_DIR}/etc/sablier/theme/warden.html"
+    fi
+
     ## generate dynamic traefik ssl termination configuration
     cat > "${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml" <<-EOT
 		tls:
 		  stores:
 		    default:
 		      defaultCertificate:
-		        certFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.crt.pem
-		        keyFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.key.pem
+		        certFile: /etc/ssl/certs/warden/${WARDEN_SERVICE_DOMAIN}.crt.pem
+		        keyFile: /etc/ssl/certs/warden/${WARDEN_SERVICE_DOMAIN}.key.pem
 		  certificates:
 	EOT
 
     for cert in $(find "${WARDEN_SSL_DIR}/certs" -type f -name "*.crt.pem" | sed -E 's#^.*/ssl/certs/(.*)\.crt\.pem$#\1#'); do
         cat >> "${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml" <<-EOF
-		    - certFile: /etc/ssl/certs/${cert}.crt.pem
-		      keyFile: /etc/ssl/certs/${cert}.key.pem
+		    - certFile: /etc/ssl/certs/warden/${cert}.crt.pem
+		      keyFile: /etc/ssl/certs/warden/${cert}.key.pem
 		EOF
     done
 

--- a/config/sablier/sablier.yml
+++ b/config/sablier/sablier.yml
@@ -1,0 +1,20 @@
+provider:
+  name: docker
+server:
+  port: 10000
+  base-path: /
+storage:
+  file:
+sessions:
+  default-duration: 5m
+  expiration-interval: 20s
+logging:
+  level: info
+strategy:
+  dynamic:
+    custom-themes-path:
+    show-details-by-default: true
+    default-theme: warden
+    default-refresh-frequency: 5s
+  blocking:
+    default-timeout: 1m

--- a/config/sablier/theme/warden.html
+++ b/config/sablier/theme/warden.html
@@ -1,0 +1,65 @@
+<html lang="en"><head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Warden</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta http-equiv="refresh" content="{{ .RefreshFrequency }}">
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin="">
+    <link rel="dns-prefetch" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css2?family=Open+Sans:wght@400;700&amp;display=swap" rel="stylesheet">
+    <style>
+        html,body {background-color:black;color:#fff;font-family:'Open Sans',sans-serif;height:100vh;margin:0;font-size:0}
+        .container {height:100vh;align-items:center;display:flex;justify-content:center;position:relative}
+        .wrap {text-align:center}
+        .ghost {animation:float 3s ease-out infinite}
+        @keyframes float { 50% {transform:translate(0,20px)}}
+        .shadowFrame {width:130px;margin: 10px auto 0 auto}
+        .shadow {animation:shrink 3s ease-out infinite;transform-origin:center center}
+        @keyframes shrink {0%{width:90%;margin:0 5%} 50% {width:60%;margin:0 18%} 100% {width:90%;margin:0 5%}}
+        h3 {font-size:17px;text-transform: uppercase;margin:0.3em auto}
+        .description {font-size:13px;color:#feb8c5}
+        .details {color:#999;width:100%}
+        .details table {width:100%}
+        .details td {white-space:nowrap;font-size:11px}
+        .details .name {text-align:right;padding-right:.6em;width:50%}
+        .details .value {text-align:left;padding-left:.6em;font-family:'Lucida Console','Courier New',monospace}
+        .details .value.error {color: rgb(231, 89, 82)}
+        .details .value.success {color: rgb(82, 231, 142)}
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="wrap">
+        
+        <pre class="warden-mark" style="
+    color: green;
+    font-size: 22px;
+    line-height: 1em;
+    font-weight: 600;
+    text-shadow: 2px 2px 3px #005003;
+"> _       __               __         
+| |     / /___ __________/ /__  ____ 
+| | /| / / __ `/ ___/ __  / _ \/ __ \
+| |/ |/ / /_/ / /  / /_/ /  __/ / / /
+|__/|__/\__,_/_/   \__,_/\___/_/ /_/ 
+            </pre>
+            <h3><span>Starting</span> {{ .DisplayName }}</h3>
+            <p class="description">Your instance(s) will stop after {{ .SessionDuration }} of inactivity</p>
+            <div class="details">
+                <table>
+                    {{- range $i, $instance := .InstanceStates }}
+                    <tr>
+                        <td class="name">{{ $instance.Name }}</td>
+                        {{- if $instance.Error }}
+                        <td class="value error">{{ $instance.Error }}</td>
+                        {{- else }}
+                        <td class="value success">{{ $instance.Status }} ({{ $instance.CurrentReplicas }}/{{ $instance.DesiredReplicas }})</td>
+                        {{- end}}
+                    </tr>
+                    {{ end -}}
+                </table>
+            </div>
+    </div>
+</div>
+
+</body></html>

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -23,3 +23,8 @@ log:
 global:
   checkNewVersion: false
   sendAnonymousUsage: false
+experimental:
+  plugins:
+    sablier:
+      moduleName: github.com/acouvreur/sablier
+      version: v1.5.0

--- a/docker/docker-compose.sablier.yml
+++ b/docker/docker-compose.sablier.yml
@@ -1,0 +1,13 @@
+version: "3.5"
+services:
+  sablier:
+    container_name: sablier
+    image: acouvreur/sablier:${SABLIER_VERSION:-latest}
+    restart: ${WARDEN_RESTART_POLICY:-always}
+    command:
+      - start
+      - --provider.name=docker
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'
+      - ${WARDEN_HOME_DIR}/etc/sablier/sablier.yml:/etc/sablier/sablier.yml
+      - ${WARDEN_HOME_DIR}/etc/sablier/theme:/etc/sablier/themes

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ${WARDEN_HOME_DIR}/etc/traefik/traefik.yml:/etc/traefik/traefik.yml
       - ${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml:/etc/traefik/dynamic.yml
-      - ${WARDEN_HOME_DIR}/ssl/certs:/etc/ssl/certs
+      - ${WARDEN_HOME_DIR}/ssl/certs:/etc/ssl/certs/warden
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       - traefik.enable=true

--- a/environments/includes/allure.base.yml
+++ b/environments/includes/allure.base.yml
@@ -13,6 +13,8 @@ services:
       # - traefik.http.routers.${WARDEN_ENV_NAME}-allure-api.tls=true
       # - traefik.http.routers.${WARDEN_ENV_NAME}-allure-api.rule=Host(`allure-api.${TRAEFIK_DOMAIN}`)
       # - traefik.http.services.${WARDEN_ENV_NAME}-allure-api.loadbalancer.server.port=5050
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
     volumes:
       - allure-results:/app/allure-results
     environment:

--- a/environments/includes/db.base.yml
+++ b/environments/includes/db.base.yml
@@ -16,6 +16,9 @@ services:
     volumes:
       - dbdata:/var/lib/mysql
       - sqlhistory:/sql_history
+    labels:
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
 
 volumes:
   dbdata:

--- a/environments/includes/elastichq.base.yml
+++ b/environments/includes/elastichq.base.yml
@@ -9,6 +9,8 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch-hq.rule=Host(`elastichq.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-elasticsearch-hq.loadbalancer.server.port=5000
       - traefik.docker.network=${WARDEN_ENV_NAME}_default
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
     environment:
       - HQ_DEFAULT_URL=http://elasticsearch:9200
 

--- a/environments/includes/elasticsearch.base.yml
+++ b/environments/includes/elasticsearch.base.yml
@@ -9,6 +9,8 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch.rule=Host(`elasticsearch.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-elasticsearch.loadbalancer.server.port=9200
       - traefik.docker.network=${WARDEN_ENV_NAME}_default
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false

--- a/environments/includes/opensearch.base.yml
+++ b/environments/includes/opensearch.base.yml
@@ -9,6 +9,8 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-opensearch.rule=Host(`opensearch.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-opensearch.loadbalancer.server.port=9200
       - traefik.docker.network=${WARDEN_ENV_NAME}_default
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
     environment:
       - DISABLE_SECURITY_PLUGIN=true
       - discovery.type=single-node

--- a/environments/includes/php-fpm.base.yml
+++ b/environments/includes/php-fpm.base.yml
@@ -30,6 +30,9 @@ services:
       - CHOWN_DIR_LIST=${CHOWN_DIR_LIST:-}
     volumes: *volumes
     extra_hosts: *extra_hosts
+    labels:
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
 
   php-debug:
     hostname: "${WARDEN_ENV_NAME}-php-debug"
@@ -48,6 +51,9 @@ services:
     extra_hosts: *extra_hosts
     depends_on:
       - php-fpm
+    labels:
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
 volumes:
   bashhistory:
   sshdirectory:

--- a/environments/includes/rabbitmq.base.yml
+++ b/environments/includes/rabbitmq.base.yml
@@ -9,6 +9,8 @@ services:
       - traefik.http.routers.${WARDEN_ENV_NAME}-rabbitmq.rule=Host(`rabbitmq.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-rabbitmq.loadbalancer.server.port=15672
       - traefik.docker.network=${WARDEN_ENV_NAME}_default
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
     volumes:
       - rabbitmq:/var/lib/rabbitmq
 

--- a/environments/includes/redis.base.yml
+++ b/environments/includes/redis.base.yml
@@ -5,6 +5,9 @@ services:
     image: ${WARDEN_IMAGE_REPOSITORY}/redis:${REDIS_VERSION:-5.0}
     volumes:
       - redis:/data
+    labels:
+      - sablier.enable=true
+      - sablier.group=${WARDEN_ENV_NAME}
 
 volumes:
   redis:

--- a/environments/includes/sablier-varnish.base.yml
+++ b/environments/includes/sablier-varnish.base.yml
@@ -1,0 +1,16 @@
+version: "3.5"
+services:
+  nginx:
+    labels:
+      - traefik.enable=false
+
+  varnish:
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.middlewares=sablier-${WARDEN_ENV_NAME}@docker
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.sablierUrl=http://sablier:10000
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.sessionDuration=${TRAEFIK_SABLIER_DURATION:-30m}
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.group=${WARDEN_ENV_NAME}
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.dynamic.name=${WARDEN_ENV_NAME}
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.dynamic.displayName=${WARDEN_ENV_NAME}
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.dynamic.theme=${TRAEFIK_SABLIER_THEME:-warden}

--- a/environments/includes/sablier.base.yml
+++ b/environments/includes/sablier.base.yml
@@ -1,0 +1,15 @@
+version: "3.5"
+services:
+  nginx:
+    networks:
+      - default
+    labels:
+      - traefik.enable=true
+      - sablier.enable=false
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.middlewares=sablier-${WARDEN_ENV_NAME}@docker
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.sablierUrl=http://sablier:10000
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.sessionDuration=${TRAEFIK_SABLIER_DURATION:-30m}
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.group=${WARDEN_ENV_NAME}
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.dynamic.name=${WARDEN_ENV_NAME}
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.dynamic.displayName=${WARDEN_ENV_NAME}
+      - traefik.http.middlewares.sablier-${WARDEN_ENV_NAME}.plugin.sablier.dynamic.theme=${TRAEFIK_SABLIER_THEME:-warden}


### PR DESCRIPTION
## Overview
Implement the [Sablier Traefik Plugin](https://plugins.traefik.io/plugins/633b4658a4caa9ddeffda119/sablier), allowing Warden to dynamic start and stop project containers on request rather than having to manage them with env up/down saving system resources for us forgetful people. Especially useful if your working on multiple large projects simultaneously, or for certain edge use cases (we run Warden also as a Ephemeral/Feature hosts deployment with a lot of projects for example).

## Implementation Notes
- Disabled by default, can be enabled via setting `WARDEN_STABLIER_ENABLE =1` in the service `.env`
- With stop all containers except the ingress (varnish/nginx depending on project configuration)
- Session lifetime can be set per project via `TRAEFIK_SABLIER_DURATION=2h` (How long before Sablier sleeps the containers)
- Custom warden theme (Good PR opportunity for someone to make it look decent)

## Configuration
Service Config:
`WARDEN_STABLIER_ENABLE=0` - Enables Sablier globally for the installation (Unable to think of a good use case of enablement on project basis)

Project :
`TRAEFIK_SABLIER_DURATION=30m` - How long Sablier waits to sleep containers
`TRAEFIK_SABLIER_THEME=ghost` - Sablier theme to use [List of Default Themes](https://acouvreur.github.io/sablier/#/themes)

Advanced:
`${WARDEN_HOME_DIR}/etc/sablier/theme` - Directory if you want to declare any custom Sablier Themes
`${WARDEN_HOME_DIR}/etc/sablier/sablier.yml` - Sablier Service Configuration Overrides