### PR TITLE
Enhancement/644 env reinstall warning

### DIFF
--- a/bin/warden
+++ b/bin/warden
@@ -17,6 +17,7 @@ export readonly WARDEN_BIN="${WARDEN_DIR}/bin/warden"
 export readonly DOCKER_COMPOSE_COMMAND="${DOCKER_COMPOSE_COMMAND:-"docker compose"}"
 
 source "${WARDEN_DIR}/utils/core.sh"
+source "${WARDEN_BIN}/utils/svc.sh"
 source "${WARDEN_DIR}/utils/env.sh"
 
 ## verify docker is installed

--- a/bin/warden
+++ b/bin/warden
@@ -2,7 +2,7 @@
 set -e
 trap 'error "$(printf "Command \`%s\` at $BASH_SOURCE:$LINENO failed with exit code $?" "$BASH_COMMAND")"' ERR
 
-## find directory where this script is located following symlinks if neccessary
+## find directory where this script is located following symlinks if necessary
 readonly WARDEN_DIR="$(
   cd "$(
     dirname "$(
@@ -17,7 +17,7 @@ export readonly WARDEN_BIN="${WARDEN_DIR}/bin/warden"
 export readonly DOCKER_COMPOSE_COMMAND="${DOCKER_COMPOSE_COMMAND:-"docker compose"}"
 
 source "${WARDEN_DIR}/utils/core.sh"
-source "${WARDEN_BIN}/utils/svc.sh"
+source "${WARDEN_DIR}/utils/svc.sh"
 source "${WARDEN_DIR}/utils/env.sh"
 
 ## verify docker is installed

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -4,7 +4,11 @@
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 assertDockerRunning
-assertSvcRunning
+
+## warn if global services are not running
+if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
+    assertSvcRunning
+fi
 
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -4,6 +4,7 @@
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 assertDockerRunning
+assertSvcRunning
 
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)

--- a/utils/svc.sh
+++ b/utils/svc.sh
@@ -7,6 +7,6 @@ function assertSvcRunning() {
     wardenNetworkId=$(docker network ls -q --filter name="${wardenNetworkName}")
 
     if [[ -z "${wardenNetworkId}" ]]; then
-        warning "Warden is not currently running.\033[0m Run \033[36mwarden svc up\033[0m to start Warden core services."
+        warning "Warden core services are not currently running.\033[0m Run \033[36mwarden svc up\033[0m to start Warden core services."
     fi
 }

--- a/utils/svc.sh
+++ b/utils/svc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
+
+function assertSvcRunning() {
+    ## test for global services running
+    wardenNetworkName=$(cat ${WARDEN_DIR}/docker/docker-compose.yml | grep -A3 'networks:' | tail -n1 | sed -e 's/[[:blank:]]*name:[[:blank:]]*//g')
+    wardenNetworkId=$(docker network ls -q --filter name="${wardenNetworkName}")
+
+    if [[ -z "${wardenNetworkId}" ]]; then
+        warning "Warden is not currently running.\033[0m Run \033[36mwarden svc up\033[0m to start Warden core services."
+    fi
+}


### PR DESCRIPTION
This is a draft PR to handle the request for #644. 

Note the current code asserts the global services are running and emits a warning and command example `warden svc up` if not.

Running `warden svc up` will run the assertWardenInstall function which checks the warden directory .installed file exists and whether the ssh_config includes values for the tunnel (which would be wiped out by an OS upgrade).

I am not sure this is the full and total solution, discuss. 

/cc @navarr @Vinai @bap14 