### PR TITLE
Add hyva back to sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This work is licensed under the MIT license. See [LICENSE](https://github.com/da
 This project was started in 2019 by [David Alger](https://davidalger.com/).
 
 # Gold Sponsors
+[![Hyvä](https://user-images.githubusercontent.com/145128/226427529-53483968-c9ab-484a-9ae3-c6abb58f81c9.png)](https://www.hyva.io/)
+
 [![Sansec.io](https://warden.dev/img/sponsors/sansec.svg)](https://www.sansec.io/)  
 
 Support Warden Development on <a href="https://opencollective.com/warden" rel="me" class="link">OpenCollective</a> or <a href="https://github.com/sponsors/wardenenv" rel="me" class="link">Github Sponsors</a>


### PR DESCRIPTION
Hyvä has sponsored twice the amount Sansec has sponsored (and continues to sponsor till date), so it seems fair to still be mentioned as Gold Sponsor.