### PR TITLE
Prevent overriding system level SSL certificates

### DIFF
--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -70,15 +70,15 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
 		  stores:
 		    default:
 		      defaultCertificate:
-		        certFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.crt.pem
-		        keyFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.key.pem
+		        certFile: /etc/ssl/certs/warden/${WARDEN_SERVICE_DOMAIN}.crt.pem
+		        keyFile: /etc/ssl/certs/warden/${WARDEN_SERVICE_DOMAIN}.key.pem
 		  certificates:
 	EOT
 
     for cert in $(find "${WARDEN_SSL_DIR}/certs" -type f -name "*.crt.pem" | sed -E 's#^.*/ssl/certs/(.*)\.crt\.pem$#\1#'); do
         cat >> "${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml" <<-EOF
-		    - certFile: /etc/ssl/certs/${cert}.crt.pem
-		      keyFile: /etc/ssl/certs/${cert}.key.pem
+		    - certFile: /etc/ssl/certs/warden/${cert}.crt.pem
+		      keyFile: /etc/ssl/certs/warden/${cert}.key.pem
 		EOF
     done
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ${WARDEN_HOME_DIR}/etc/traefik/traefik.yml:/etc/traefik/traefik.yml
       - ${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml:/etc/traefik/dynamic.yml
-      - ${WARDEN_HOME_DIR}/ssl/certs:/etc/ssl/certs
+      - ${WARDEN_HOME_DIR}/ssl/certs:/etc/ssl/certs/warden
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       - traefik.enable=true


### PR DESCRIPTION
This pull request proposes mounting the warden self signed certs to a warden subdirectory within the same location.

Currently warden is mounting the self signed SSL certificates to `/etc/ssl/certs/`. In the process it inadvertently removes all the system certificates.  

As a result, you are unable to install any Traefik plugins as it fails to verify the TLS certificate. With the following error message in the Traefik logs.
```sh
traefik  | time="2024-10-20T20:58:40Z" level=error msg="Plugins are disabled because an error has occurred." error="failed to download plugin github.com/acouvreur/sablier: failed to call service: Get \"https://plugins.traefik.io/public/download/github.com/acouvreur/sablier/v1.5.0\": tls: failed to verify certificate: x509: certificate signed by unknown authority"
```

## Reproduction Steps
1. Set your Traefik version to one that supports plugins `echo TRAEFIK_VERSION=2.9 >> ~/.warden/.env`
2. Install a plugin by appending the following to the `traefik.yml` configuration 
```yml
experimental:
  plugins:
    sablier:
      moduleName: github.com/acouvreur/sablier
      version: v1.5.0
```
3. Start the warden svc and tail the traefik logs `warden svc up && warden svc logs traefik -f`