### PR TITLE
Migrate Traefik Configuration To Environment Variables

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       - "${TRAEFIK_LISTEN:-127.0.0.1}:80:80"     # The HTTP port
       - "${TRAEFIK_LISTEN:-127.0.0.1}:443:443"   # The HTTPS port
     volumes:
-      - ${WARDEN_HOME_DIR}/etc/traefik/traefik.yml:/etc/traefik/traefik.yml
       - ${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml:/etc/traefik/dynamic.yml
       - ${WARDEN_HOME_DIR}/ssl/certs:/etc/ssl/certs
       - /var/run/docker.sock:/var/run/docker.sock
@@ -16,6 +15,24 @@ services:
       - traefik.http.routers.traefik.rule=Host(`traefik.${WARDEN_SERVICE_DOMAIN:-warden.test}`)
       - traefik.http.routers.traefik.service=api@internal
     restart: ${WARDEN_RESTART_POLICY:-always}
+    environment:
+      TRAEFIK_API: true
+      TRAEFIK_API_DASHBOARD: true
+      TRAEFIK_PROVIDERS_FILE_FILENAME: /etc/traefik/dynamic.yml
+      TRAEFIK_PROVIDERS_DOCKER: true
+      TRAEFIK_PROVIDERS_DOCKER_DEFAULTRULE: "Host(`{{ .Name }}.warden.test`)"
+      TRAEFIK_PROVIDERS_DOCKER_NETWORK: warden
+      TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT: false
+      TRAEFIK_ENTRYPOINTS_HTTP: true
+      TRAEFIK_ENTRYPOINTS_HTTP_ADDRESS: :80
+      TRAEFIK_ENTRYPOINTS_HTTP_HTTP_REDIRECTIONS_ENTRYPOINT_SCHEME: https
+      TRAEFIK_ENTRYPOINTS_HTTP_HTTP_REDIRECTIONS_ENTRYPOINT_TO: https
+      TRAEFIK_ENTRYPOINTS_HTTPS: true
+      TRAEFIK_ENTRYPOINTS_HTTPS_ADDRESS: :443
+      TRAEFIK_LOG: true
+      TRAEFIK_LOG_LEVEL: info
+      TRAEFIK_GLOBAL_CHECKNEWVERSION: false
+      TRAEFIK_GLOBAL_SENDANONYMOUSUSAGE: false
 
   tunnel:
     container_name: tunnel


### PR DESCRIPTION
Currently overriding / extending the `traefik.yml` configuration is difficult. This PR proposes migrating the Traefik configuration from the `.yml` file to environment variables. This should improve both the extendability and maintainability of attempting to extend the Traefik config. Such as, but not limited to configuring plugins or certificate resolvers.

I've found there are 2 main pain points to the current approach.

1. You have to overwrite and maintain the whole configuration file, even for a single value change. 
2. You have to edit the source file, since the `svc up` command replaces any modifications under `$HOME/.warden/etc/traefik/traefik.yml` [See Here](https://github.com/wardenenv/warden/blob/main/commands/svc.cmd#L65)

Note: May be considered a breaking change. Since any custom changes to the `traefik.yml` by users would have to be reimplemented via the ENV approach. Due to [Traefik static config approaches being mutually exclusive](https://doc.traefik.io/traefik/getting-started/configuration-overview/#the-static-configuration). 

---

## Example Use Case

Say you want to enable debug logging for Traefik. With the environment variable approach you can create a docker compose file in the warden home directory with the following contents. 
```yml
# ~/.warden/docker-compose.yml
services:
  traefik:
      TRAEFIK_LOG_LEVEL: DEBUG
```

Or if you want to define a certificate resolver such as LetsEncrypt to sign your certs. It can again be defined in the users home directory with the following docker compose file. [See this issue of someone attempting a similar thing and having to override the source file](https://github.com/wardenenv/warden/issues/540#issuecomment-1281177584)
```yml
# ~/.warden/docker-compose.yml
services:
  traefik:
    volumes:
      - acmedata:/acme
    environment:
      CF_DNS_API_TOKEN: xxx
      CF_ZONE_API_TOKEN: xxx
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT: true
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL: admin@example.com
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_STORAGE: /acme/acme.json
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_CASERVER: https://acme-staging-v02.api.letsencrypt.org/directory
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_DNSCHALLENGE: true
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_DNSCHALLENGE_PROVIDER: cloudflare
volumes:
  acmedata:
```