### PR TITLE
fix(svc.cmd): ensure phpMyAdmin config file is consistently managed

### DIFF
--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -45,6 +45,13 @@ fi
 
 WARDEN_PHPMYADMIN_ENABLE="${WARDEN_PHPMYADMIN_ENABLE:-1}"
 if [[ "${WARDEN_PHPMYADMIN_ENABLE}" == 1 ]]; then
+    if [[ -d "${WARDEN_HOME_DIR}/etc/phpmyadmin/config.user.inc.php" ]]; then
+        rm -rf ${WARDEN_HOME_DIR}/etc/phpmyadmin/config.user.inc.php
+    fi
+    if [[ ! -f "${WARDEN_HOME_DIR}/etc/phpmyadmin/config.user.inc.php" ]]; then
+        mkdir -p "${WARDEN_HOME_DIR}/etc/phpmyadmin"
+        touch ${WARDEN_HOME_DIR}/etc/phpmyadmin/config.user.inc.php
+    fi
     DOCKER_COMPOSE_ARGS+=("-f")
     DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/docker/docker-compose.phpmyadmin.yml")
 fi
@@ -71,11 +78,6 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
     ## copy configuration files into location where they'll be mounted into containers from
     mkdir -p "${WARDEN_HOME_DIR}/etc/traefik"
     cp "${WARDEN_DIR}/config/traefik/traefik.yml" "${WARDEN_HOME_DIR}/etc/traefik/traefik.yml"
-
-    if [[ "${WARDEN_PHPMYADMIN_ENABLE}" == 1 && \
-        ! -f "${WARDEN_HOME_DIR}/etc/phpmyadmin/config.user.inc.php" ]]; then
-        mkdir -p "${WARDEN_HOME_DIR}/etc/phpmyadmin"
-    fi
 
     ## generate dynamic traefik ssl termination configuration
     cat > "${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml" <<-EOT


### PR DESCRIPTION
Add checks to remove outdated phpMyAdmin config file if it exists and create a new one if absent. Clean up redundant directory creation steps.

https://github.com/wardenenv/warden/issues/823
