### PR TITLE
Add test for svc enabled and cmd up before calling regeneratePMAConfig

### DIFF
--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -114,6 +114,8 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
     for network in $(docker network ls -f label=dev.warden.environment.name --format {{.Name}}); do
         connectPeeredServices "${network}"
     done
-fi
 
-regeneratePMAConfig
+    if [[ "${WARDEN_PHPMYADMIN_ENABLE}" == 1 ]]; then
+        regeneratePMAConfig
+    fi
+fi


### PR DESCRIPTION
Add proper checks for command up and service enabled before calling regeneratePMAConfig.

<!-- [BUG] Feel free to delete everything between the bug tags if not a bug -->
**Check List**
- [x] Is there an existing issue that covers this? (#852)
- [ ] Is there an entry in the CHANGELOG.md file?