### PR TITLE
Feature add a warden doctor command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   This support should be considered experimental.  Your Adobe Commerce application should already be setup and configured
   before turning on the GraphQL Application Flag.  You can enable GraphQL with the flag `WARDEN_MAGENTO2_GRAPHQL_SERVER=1`
   or run it using a debug PHP image by including the additional flag `WARDEN_MAGENTO2_GRAPHQL_SERVER_DEBUG=1`
+* Added top level Warden debug information command `warden doctor` by @hardyjohnson
 
 **Enhancements:**
 * Add ability to run vite bundler in warden for Laravel. See: [Laravel + Vite](https://docs.warden.dev/environments/laravel.html) ([#846](https://github.com/wardenenv/warden/issues/846) by @bap14)

--- a/commands/doctor.cmd
+++ b/commands/doctor.cmd
@@ -8,37 +8,67 @@
 ## darwin
 # > sw_vers
 
-sw_vers --productName
-sw_vers --productVersion
+if [[ $OSTYPE =~ ^darwin ]]; then
+    echo -e "\033[032mHost information:\033[0m"
+    sw_vers --productName
+    sw_vers --productVersion
+fi
 echo
 
+echo -e "\033[32mOS, version, architecture:\033[0m"
+uname -orm
+echo
 
+echo -e "\033[32mHomebrew information:\033[0m"
+brew config
+echo
+
+echo -e "\033[32mContainer runtime and compose information:\033[0m"
 docker --version
 ${DOCKER_COMPOSE_COMMAND} version
-
 echo
 
-echo "Warden version:" $(${WARDEN_BIN} version)
+echo -e "\033[32mWarden version:\033[0m"
+echo $(${WARDEN_BIN} version)
 echo
 
-echo "Warden image, tag and architecture: "
+echo -e "\033[32mWarden global .env:\033[0m"
+cat ~/.warden/.env
 echo
+
+echo -e "\033[32mWarden service override via Docker compose file:\033[0m"
+if [[ -f ~/.warden/docker-compose.yml ]]; then
+    echo -e "\033[33mWarden services have additional service configuration added or overridden via ~/.warden/docker-compose.yml file.\033[0m"
+else
+    echo -e "\033[33mWarden services do not appear to be overridden via ~/.warden/docker-compose.yml file.\033[0m"
+fi
+echo
+
+echo -e "\033[32mWarden service override via ~/.warden/warden-env.yml partial:\033[0m"
+if [[ -f ~/.warden/warden-env.yml ]]; then
+    echo -e "\033[33mWarden services have additional service configuration added or overridden via ~/.warden/warden-env.yml partial.\033[0m"
+else
+    echo -e "\033[33mWarden services do not appear to be overridden via ~/.warden/warden-env.yml partial.\033[0m"
+fi
+echo
+
+echo -e "\033[32mWarden image, tag and architecture:\033[0m"
 WARDEN_IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -i wardenenv)
 for img in ${WARDEN_IMAGES}; do
     echo $img:$(docker image inspect $img --format "{{.Architecture}}");
 done
 echo
 
+echo -e "\033[32mWarden environments and service configuration files :\033[0m"
 ${WARDEN_BIN} svc ls -a --format json | jq '.[] | (.Name + " - " + .Status), (.ConfigFiles | split(","))'
 echo
 
+echo -e "\033[32mWarden status:\033[0m"
 "$WARDEN_BIN" status
 echo
 
-mutagen sync list
+if [[ ${WARDEN_MUTAGEN_ENABLE} -eq 1 ]]; then
+    echo -e "\033[32mMutagen sync list\033[0m"
+    mutagen sync list
+fi
 echo
-
-# ssh information related warden / warden project
-# any docker inspect or configuration information
-
-# echo "Warden doctor complete!"

--- a/commands/doctor.cmd
+++ b/commands/doctor.cmd
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
+
+# The warden doctor command is designed to collect information useful in reasoning about the
+# state of a system and configuration warden is running with.
+
+# Host information
+## darwin
+# > sw_vers
+
+sw_vers --productName
+sw_vers --productVersion
+echo
+
+
+docker --version
+${DOCKER_COMPOSE_COMMAND} version
+
+echo
+
+echo "Warden version:" $(${WARDEN_BIN} version)
+echo
+
+echo "Warden image, tag and architecture: "
+echo
+WARDEN_IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -i wardenenv)
+for img in ${WARDEN_IMAGES}; do
+    echo $img:$(docker image inspect $img --format "{{.Architecture}}");
+done
+echo
+
+${WARDEN_BIN} svc ls -a --format json | jq '.[] | (.Name + " - " + .Status), (.ConfigFiles | split(","))'
+echo
+
+"$WARDEN_BIN" status
+echo
+
+mutagen sync list
+echo
+
+# ssh information related warden / warden project
+# any docker inspect or configuration information
+
+# echo "Warden doctor complete!"

--- a/commands/doctor.help
+++ b/commands/doctor.help
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
+
+WARDEN_USAGE=$(cat <<EOF
+\033[33mUsage:\033[0m
+  doctor [args]
+
+\033[33mOptions:\033[0m
+  -h, --help        Display this help menu
+EOF
+)

--- a/commands/usage.help
+++ b/commands/usage.help
@@ -20,17 +20,18 @@ Warden version $(cat ${WARDEN_DIR}/version)
   -h, --help        Display this help menu
 
 \033[33mCommands:\033[0m
-  svc               Orchestrates global services such as traefik, portainer and dnsmasq via docker compose
-  env-init          Configure environment by adding '.env' file to the current working directory
-  env               Controls an environment from any point within the root project directory
   db                Interacts with the db service on an environment (see 'warden db -h' for details)
-  redis             Interacts with the redis service on an environment (see 'warden redis -h' for details)
-  install           Initializes or updates warden configuration on host machine
-  shell             Launches into a shell within the current project environment
-  status            Display list of all running Warden project environments
   debug             Launches debug enabled shell within current project environment
-  spx               Launches spx enabled shell within current project environment
+  doctor            Software information for bug reports
+  env               Controls an environment from any point within the root project directory
+  env-init          Configure environment by adding '.env' file to the current working directory
+  install           Initializes or updates warden configuration on host machine
+  redis             Interacts with the redis service on an environment (see 'warden redis -h' for details)
+  shell             Launches into a shell within the current project environment
   sign-certificate  Signs a wildcard certificate including all passed hostnames on the SAN list
+  spx               Launches spx enabled shell within current project environment
+  status            Display list of all running Warden project environments
+  svc               Orchestrates global services such as traefik, portainer and dnsmasq via docker compose
   version           Show version information
 EOF
 )


### PR DESCRIPTION
<!-- [FEATURE] Feel free to delete everything between the [FEATURE] tags if not a new feature -->
**Check List**
- [ ] Matching PR in the documentation repo (replace text with link when it exists)
- [x] Entry in CHANGELOG.md

**Is your feature request related to a problem? Please describe.**  

New command: `warden doctor` similar to the Homebrew project's `brew doctor` command.

This command is intended to help debug the local environment, taking into account the different ways a warden environment can be setup and configured, especially to help in identifying bugs as part of the warden project.

This was previously discussed here: https://github.com/orgs/wardenenv/discussions/851#discussion-8106360

Command outputs the following information:

1. Host OS and version
1. Host processor architecture
1. Brew information
1. Container runtime and compose information
1. Warden version
1. Warden global .env
1. Warden override detection for extension at the global level (~/.warden/docker-compose.yml and ~/.warden/warden-env.yml)
1. Warden images, versions and architecture
1. Warden environments and service configuration files
1. Warden status
1. Mutagen sync file list if Mutagen is enabled

**Example**

```
> warden doctor

Host information:
macOS
15.4

OS, version, architecture:
Darwin 24.4.0 arm64

Homebrew information:
HOMEBREW_VERSION: 4.4.27
ORIGIN: https://github.com/Homebrew/brew
HEAD: 9b1efcd944408db0bd85f82fe4724ccae04a812f
Last commit: 14 hours ago
Branch: stable
Core tap JSON: 31 Mar 21:43 UTC
Core cask tap JSON: 31 Mar 21:43 UTC
HOMEBREW_PREFIX: /opt/homebrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_EDITOR: nano
HOMEBREW_GITHUB_API_TOKEN: set
HOMEBREW_MAKE_JOBS: 12
Homebrew Ruby: 3.3.7 => /opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.3.7/bin/ruby
CPU: dodeca-core 64-bit arm_blizzard_avalanche
Clang: 16.0.0 build 1600
Git: 2.49.0 => /opt/homebrew/bin/git
Curl: 8.7.1 => /usr/bin/curl
macOS: 15.4-arm64
CLT: 16.2.0.0.1.1733547573
Xcode: 16.2
Rosetta 2: false

Container runtime and compose information:
Docker version 28.0.1, build 068a01e
Docker Compose version v2.33.1-desktop.1

Warden version:
in-dev

Warden global .env:
# Set to "1" to enable global Portainer service
WARDEN_PORTAINER_ENABLE=0
# SEt to "0" to disable DNSMasq
WARDEN_DNSMASQ_ENABLE=1

WARDEN_PHPMYADMIN_ENABLE=1

Warden service override via Docker compose file:
Warden services do not appear to be overridden via ~/.warden/docker-compose.yml file.

Warden service override via ~/.warden/warden-env.yml partial:
Warden services do not appear to be overridden via ~/.warden/warden-env.yml partial.

Warden image, tag and architecture:
wardenenv/php-fpm:7.4-xdebug3:arm64
wardenenv/php-fpm:7.4:arm64
wardenenv/varnish:7.6:arm64
wardenenv/nginx:1.16:arm64
wardenenv/opensearch:2.12:arm64
wardenenv/dnsmasq:latest:arm64
wardenenv/php-fpm:8.3-magento2-xdebug3:arm64
wardenenv/php-fpm:8.3-magento2:arm64
wardenenv/mariadb:10.6:arm64
wardenenv/redis:7.2:arm64
wardenenv/rabbitmq:3.13:arm64
wardenenv/mariadb:10.4:arm64

Warden environments and service configuration files :
"acdemo - running(8)"
[
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/networks.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/php-fpm.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/php-fpm.darwin.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/nginx.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/nginx.darwin.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/db.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/magento2/db.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/opensearch.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/varnish.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/rabbitmq.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/includes/redis.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/magento2/magento2.base.yml",
  "/Users/computeruser/code/opensource/wardenenv/warden/environments/magento2/magento2.mutagen_compose.yml",
  "/Users/computeruser/code/adobecommerce/.warden/warden-env.yml"
]
"wordpress - created(3), exited(2)"
[
  "/opt/homebrew/Cellar/warden/0.15.0/environments/includes/networks.base.yml",
  "/opt/homebrew/Cellar/warden/0.15.0/environments/includes/php-fpm.base.yml",
  "/opt/homebrew/Cellar/warden/0.15.0/environments/includes/php-fpm.darwin.yml",
  "/opt/homebrew/Cellar/warden/0.15.0/environments/includes/nginx.base.yml",
  "/opt/homebrew/Cellar/warden/0.15.0/environments/includes/nginx.darwin.yml",
  "/opt/homebrew/Cellar/warden/0.15.0/environments/includes/db.base.yml",
  "/opt/homebrew/Cellar/warden/0.15.0/environments/wordpress/db.base.yml",
  "/opt/homebrew/Cellar/warden/0.15.0/environments/includes/elastichq.base.yml",
  "/opt/homebrew/Cellar/warden/0.15.0/environments/wordpress/wordpress.base.yml"
]

Warden status:
Found the following running environments:
    acdemo a magento2 project
       Project Directory: /Users/computeruser/code/adobecommerce
       Project URL: https://app.acdemo.test

```
