### PR TITLE
Create Valkey env variables, docker partials, and cli commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 **Big Changes:**
 * PHP SPX support ([#820](https://github.com/wardenenv/warden/pull/820) by @SamJUK)
-* phpMyAdmin added to Warden core services ([#801](https://github.com/wardenenv/warden/pull/801) by @monteshot)
+* phpMyAdmin added to Warden core services ([#801](https://github.com/wardenenv/warden/pull/801) by @monteshot and bugfixes by @hardyjohnson)
 * Added support for **Adobe Commerce GraphQL Application Server**  
   This support should be considered experimental.  Your Adobe Commerce application should already be setup and configured
   before turning on the GraphQL Application Flag.  You can enable GraphQL with the flag `WARDEN_MAGENTO2_GRAPHQL_SERVER=1`
@@ -13,6 +13,7 @@
 
 **Enhancements:**
 * Add ability to run vite bundler in warden for Laravel. See: [Laravel + Vite](https://docs.warden.dev/environments/laravel.html) ([#846](https://github.com/wardenenv/warden/issues/846) by @bap14)
+* Added Valkey service ([#861](https://github.com/wardenenv/warden#861) by @navarr)
 
 **Bug Fixes:**
 * System-level SSL certificates are no longer overwritten ([#812](https://github.com/wardenenv/warden/pull/812) by @SamJUK)

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -107,6 +107,9 @@ fi
 [[ ${WARDEN_REDIS} -eq 1 ]] \
     && appendEnvPartialIfExists "redis"
 
+[[ ${WARDEN_VALKEY:=0} -eq 1 ]] \
+    && appendEnvPartialIfExists "valkey"
+
 appendEnvPartialIfExists "${WARDEN_ENV_TYPE}"
 
 [[ ${WARDEN_TEST_DB} -eq 1 ]] \

--- a/commands/usage.help
+++ b/commands/usage.help
@@ -25,6 +25,7 @@ Warden version $(cat ${WARDEN_DIR}/version)
   env               Controls an environment from any point within the root project directory
   db                Interacts with the db service on an environment (see 'warden db -h' for details)
   redis             Interacts with the redis service on an environment (see 'warden redis -h' for details)
+  valkey            Interacts with the Valkey service on an environment (see 'warden valkey -h' for details)
   install           Initializes or updates warden configuration on host machine
   shell             Launches into a shell within the current project environment
   status            Display list of all running Warden project environments

--- a/commands/valkey.cmd
+++ b/commands/valkey.cmd
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
+
+WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
+loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
+assertDockerRunning
+
+if [[ ${WARDEN_VALKEY:-1} -eq 0 ]]; then
+  fatal "Valkey environment is not used (WARDEN_VALKEY=0)."
+fi
+
+if [[ "${WARDEN_PARAMS[0]}" == "help" ]]; then
+  $WARDEN_BIN valkey --help || exit $? && exit $?
+fi
+
+## load connection information for the Valkey service
+VALKEY_CONTAINER=$($WARDEN_BIN env ps -q valkey)
+if [[ ! ${VALKEY_CONTAINER} ]]; then
+    fatal "No container found for Valkey service."
+fi
+
+"$WARDEN_BIN" env exec valkey valkey-cli "${WARDEN_PARAMS[@]}" "$@"

--- a/commands/valkey.help
+++ b/commands/valkey.help
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
+
+WARDEN_USAGE=$(cat <<EOF
+\033[33mUsage:\033[0m
+  valkey                     Launches an interactive Valkey session within the current project environment
+  valkey COMMAND             Execute any valid Valkey command within the current project environment
+
+\033[33mOptions:\033[0m
+  -h, --help        Display this help menu
+EOF
+)

--- a/environments/includes/valkey.base.yml
+++ b/environments/includes/valkey.base.yml
@@ -1,0 +1,9 @@
+services:
+  valkey:
+    hostname: "${WARDEN_ENV_NAME}-valkey"
+    image: ${WARDEN_IMAGE_REPOSITORY}/valkey:${VALKEY_VERSION:-8.1}
+    volumes:
+      - valkey:/data
+
+volumes:
+  valkey:


### PR DESCRIPTION
Ticket: #860 

To enable Valkey, the new environment variables have been added:
- WARDEN_VALKEY_ENABLE
- VALKEY_VERSION

<!-- [FEATURE] Feel free to delete everything between the [FEATURE] tags if not a new feature -->
**Check List**
- [x] wardenenv/docs#36
- [x] Entry in CHANGELOG.md
- [x] Add `valkey` command that works like the `redis` command but for Valkey (or should the `redis` command intelligently work?)

**Is your feature request related to a problem? Please describe.**  
Magento 2.4.8 moves Magento from Redis to the Valkey fork, with explicit support for Valkey and a lack of Redis on the requirements table.  This PR adds support for VALKEY to Warden, while maintaining support for Redis. 

**Describe the solution you've submitted**  
I considered whether to use the approach we used for MySQL (with the distribution type and distribution version), but have decided to take the approach we did with ElasticSearch v OpenSearch; where both Redis and Valkey can independently be enabled.

If a Warden `.env` file contains `WARDEN_VALKEY=1`, Valkey will be enabled (and Valkey is not enabled by default).

If a Warden `.env` file contains `VALKEY_VERSION` it will use that as the tag for the Valkey image from the Warden repository. 
<!-- [/FEATURE] -->