### PR TITLE
Switch to selenium from seleniarm

### DIFF
--- a/environments/includes/selenium.base.yml
+++ b/environments/includes/selenium.base.yml
@@ -1,7 +1,7 @@
 services:
   selenium:
     hostname: ${WARDEN_ENV_NAME}_selenium
-    image: seleniarm/standalone-chromium:${WARDEN_SELENIUM_VERSION:-latest}
+    image: selenium/standalone-chromium:${WARDEN_SELENIUM_VERSION:-latest}
     extra_hosts:
       - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}


### PR DESCRIPTION
This PR moves back over to the original `selenium` repository as `seleniarm` has been merged back to the main project, as noted on the https://github.com/seleniumhq-community/docker-seleniarm README.

> The fork was merged into the main project [Docker Selenium](https://github.com/SeleniumHQ/docker-selenium) and published multi-arch images on [Selenium](https://hub.docker.com/r/selenium/) Docker Hub registry. [Read more](https://www.selenium.dev/blog/2024/multi-arch-images-via-docker-selenium/).
