### PR TITLE
Add test for existing configuration

### DIFF
--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -75,9 +75,14 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
         "$WARDEN_BIN" sign-certificate "${WARDEN_SERVICE_DOMAIN}"
     fi
 
+    if [[ ! -d "${WARDEN_HOME_DIR}/etc/traefik" ]]; then
+        mkdir -p "${WARDEN_HOME_DIR}/etc/traefik"
+    fi
+
     ## copy configuration files into location where they'll be mounted into containers from
-    mkdir -p "${WARDEN_HOME_DIR}/etc/traefik"
-    cp "${WARDEN_DIR}/config/traefik/traefik.yml" "${WARDEN_HOME_DIR}/etc/traefik/traefik.yml"
+    if [[ ! -f "${WARDEN_HOME_DIR}/etc/traefik/traefik.yml" ]]; then
+        cp "${WARDEN_DIR}/config/traefik/traefik.yml" "${WARDEN_HOME_DIR}/etc/traefik/traefik.yml"
+    fi
 
     ## generate dynamic traefik ssl termination configuration
     cat > "${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml" <<-EOT


### PR DESCRIPTION
Test for Warden home traefik configuration directory and file before copying over them with versions from the Warden install directory.

<!-- [BUG] Feel free to delete everything between the bug tags if not a bug -->
**Check List**
- [x] Is there an existing issue that covers this? (#876)
- [ ] Is there an entry in the CHANGELOG.md file?
