### PR TITLE
Strip MariaDB sandbox command on DB import

### DIFF
--- a/commands/db.cmd
+++ b/commands/db.cmd
@@ -36,6 +36,7 @@ case "${WARDEN_PARAMS[0]}" in
     import)
         LC_ALL=C sed -E 's/DEFINER[ ]*=[ ]*`[^`]+`@`[^`]+`/DEFINER=CURRENT_USER/g' \
             | LC_ALL=C sed -E '/\@\@(GLOBAL\.GTID_PURGED|SESSION\.SQL_LOG_BIN)/d' \
+            | LC_ALL=C sed -E '/\/\*!999999\\- enable the sandbox mode \*\//d' \
             | "$WARDEN_BIN" env exec -T db \
             mysql -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" --database="${MYSQL_DATABASE}" "${WARDEN_PARAMS[@]:1}" "$@"
         ;;


### PR DESCRIPTION
This PR strips the MariaDB sandbox command that is inserted into the top of database dumps taken from recent versions.

`/*!999999\- enable the sandbox mode */`

Ref: https://mariadb.org/mariadb-dump-file-compatibility-change/

This command can cause an error on `warden db import` when exporting/importing between different MariaDB versions.

ERROR at line 1: Unknown command '\-'.