### PR TITLE
Bugfix for issue #933

### DIFF
--- a/environments/includes/nginx.base.yml
+++ b/environments/includes/nginx.base.yml
@@ -6,6 +6,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.priority=2
+      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.ruleSyntax=v2
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=
           HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-nginx.loadbalancer.server.port=80


### PR DESCRIPTION
Set the label ruleSyntax on routers to keep backwards compatibility on Traefik v3

<!-- [BUG] Feel free to delete everything between the bug tags if not a bug -->
**Check List**
- [x] Is there an existing issue that covers this? https://github.com/wardenenv/warden/issues/933
- [ ] Is there an entry in the CHANGELOG.md file?