### PR TITLE
Fix compatibility with MariaDB 12 (and future versions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 **Bug Fixes:**
 * Add support to dynamically connect peered services based on enabled status ([#892](https://github.com/wardenenv/warden/issues/892) by @bap14, [#919](https://github.com/wardenenv/warden/issues/919) by @xinsodev)
 * Fix WARDEN_DOCKER_SOCK error running `warden sign-certificate` ([#907](https://github.com/wardenenv/warden/issues/907) by @bap14)
+* Allow DB service entrypoint script to determine the correct mysql/mariadb command ([#864](https://github.com/wardenenv/warden/issues/864) by @mattijv)
 
 ## Version [0.16.0](https://github.com/wardenenv/warden/tree/0.16.0) (2026-02-12)
 

--- a/commands/db.cmd
+++ b/commands/db.cmd
@@ -27,21 +27,33 @@ eval "$(
     ' | grep "^MYSQL_"
 )"
 
+## determine the client commands to use based on the database distribution
+case "${MYSQL_DISTRIBUTION}" in
+    mariadb)
+        clientCmd="mariadb"
+        dumpCmd="mariadb-dump"
+        ;;
+    *)
+        clientCmd="mysql"
+        dumpCmd="mysqldump"
+        ;;
+esac
+
 ## sub-command execution
 case "${WARDEN_PARAMS[0]}" in
     connect)
         "$WARDEN_BIN" env exec db \
-            mysql -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" --database="${MYSQL_DATABASE}" "${WARDEN_PARAMS[@]:1}" "$@"
+            "${clientCmd}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" --database="${MYSQL_DATABASE}" "${WARDEN_PARAMS[@]:1}" "$@"
         ;;
     import)
         LC_ALL=C sed -E 's/DEFINER[ ]*=[ ]*`[^`]+`@`[^`]+`/DEFINER=CURRENT_USER/g' \
             | LC_ALL=C sed -E '/\@\@(GLOBAL\.GTID_PURGED|SESSION\.SQL_LOG_BIN)/d' \
             | "$WARDEN_BIN" env exec -T db \
-            mysql -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" --database="${MYSQL_DATABASE}" "${WARDEN_PARAMS[@]:1}" "$@"
+            "${clientCmd}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" --database="${MYSQL_DATABASE}" "${WARDEN_PARAMS[@]:1}" "$@"
         ;;
     dump)
             "$WARDEN_BIN" env exec -T db \
-            mysqldump -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" "${WARDEN_PARAMS[@]:1}" "$@"
+            "${dumpCmd}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" "${WARDEN_PARAMS[@]:1}" "$@"
         ;;
     upgrade)
             if [ "$MYSQL_DISTRIBUTION" == "mysql" ]; then
@@ -54,7 +66,7 @@ case "${WARDEN_PARAMS[0]}" in
             fi
 
             "$WARDEN_BIN" env exec -T db \
-            ${upgradeCmd} -p"${MYSQL_ROOT_PASSWORD}"
+            "${upgradeCmd}" -p"${MYSQL_ROOT_PASSWORD}"
         ;;
     *)
         fatal "The command \"${WARDEN_PARAMS[0]}\" does not exist. Please use --help for usage."

--- a/environments/cakephp/db.base.yml
+++ b/environments/cakephp/db.base.yml
@@ -6,7 +6,6 @@ services:
       - MYSQL_USER=${MYSQL_USER:-cakephp}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-cakephp}
     command:
-      - mysqld
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on
       - --transaction-isolation=READ-COMMITTED

--- a/environments/cakephp/db.base.yml
+++ b/environments/cakephp/db.base.yml
@@ -5,6 +5,7 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-cakephp}
       - MYSQL_USER=${MYSQL_USER:-cakephp}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-cakephp}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}
     command:
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on

--- a/environments/drupal/db.base.yml
+++ b/environments/drupal/db.base.yml
@@ -5,6 +5,7 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-drupal}
       - MYSQL_USER=${MYSQL_USER:-drupal}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-drupal}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}
     command:
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on

--- a/environments/drupal/db.base.yml
+++ b/environments/drupal/db.base.yml
@@ -6,7 +6,6 @@ services:
       - MYSQL_USER=${MYSQL_USER:-drupal}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-drupal}
     command:
-      - mysqld
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on
       - --transaction-isolation=READ-COMMITTED

--- a/environments/includes/db.base.yml
+++ b/environments/includes/db.base.yml
@@ -12,6 +12,7 @@ services:
       - MYSQL_USER=${MYSQL_USER:-app}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-app}
       - MYSQL_HISTFILE=/sql_history/.sql_history
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}
     volumes:
       - dbdata:/var/lib/mysql
       - sqlhistory:/sql_history

--- a/environments/laravel/db.base.yml
+++ b/environments/laravel/db.base.yml
@@ -5,3 +5,4 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-laravel}
       - MYSQL_USER=${MYSQL_USER:-laravel}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-laravel}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}

--- a/environments/magento1/db.base.yml
+++ b/environments/magento1/db.base.yml
@@ -5,5 +5,6 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-magento}
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}
     command:
       - --max_allowed_packet=1024M

--- a/environments/magento1/db.base.yml
+++ b/environments/magento1/db.base.yml
@@ -6,5 +6,4 @@ services:
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
     command:
-      - mysqld
       - --max_allowed_packet=1024M

--- a/environments/magento2/db.base.yml
+++ b/environments/magento2/db.base.yml
@@ -6,6 +6,5 @@ services:
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
     command:
-      - mysqld
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on

--- a/environments/magento2/db.base.yml
+++ b/environments/magento2/db.base.yml
@@ -5,6 +5,7 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-magento}
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}
     command:
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on

--- a/environments/magento2/magento2.splitdb.checkout.base.yml
+++ b/environments/magento2/magento2.splitdb.checkout.base.yml
@@ -15,6 +15,7 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-magento}
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}
     command:
       - --max_allowed_packet=1024M
     volumes:

--- a/environments/magento2/magento2.splitdb.checkout.base.yml
+++ b/environments/magento2/magento2.splitdb.checkout.base.yml
@@ -16,7 +16,6 @@ services:
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
     command:
-      - mysqld
       - --max_allowed_packet=1024M
     volumes:
       - checkoutdbdata:/var/lib/mysql

--- a/environments/magento2/magento2.splitdb.sales.base.yml
+++ b/environments/magento2/magento2.splitdb.sales.base.yml
@@ -15,6 +15,7 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-magento}
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}
     command:
       - --max_allowed_packet=1024M
     volumes:

--- a/environments/magento2/magento2.splitdb.sales.base.yml
+++ b/environments/magento2/magento2.splitdb.sales.base.yml
@@ -16,7 +16,6 @@ services:
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
     command:
-      - mysqld
       - --max_allowed_packet=1024M
     volumes:
       - salesdbdata:/var/lib/mysql

--- a/environments/magento2/magento2.tests.base.yml
+++ b/environments/magento2/magento2.tests.base.yml
@@ -8,7 +8,6 @@ services:
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
     command:
-      - mysqld
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on
     volumes:

--- a/environments/magento2/magento2.tests.base.yml
+++ b/environments/magento2/magento2.tests.base.yml
@@ -7,6 +7,7 @@ services:
       - MYSQL_DATABASE=magento_integration_tests
       - MYSQL_USER=${MYSQL_USER:-magento}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-magento}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}
     command:
       - --max_allowed_packet=1024M
       - --explicit_defaults_for_timestamp=on

--- a/environments/shopware/db.base.yml
+++ b/environments/shopware/db.base.yml
@@ -21,5 +21,9 @@ services:
     entrypoint: |
       /bin/bash -c '
         echo "$$DB_AUTO_CREATE_SH" > /docker-entrypoint-initdb.d/db-auto-create.sh
-        exec /usr/local/bin/docker-entrypoint.sh mysqld
+        case "${MYSQL_DISTRIBUTION:-mariadb}" in
+          mariadb) DB_DAEMON=mariadbd ;;
+          *) DB_DAEMON=mysqld ;;
+        esac
+        exec /usr/local/bin/docker-entrypoint.sh "$$DB_DAEMON"
       '

--- a/environments/shopware/db.base.yml
+++ b/environments/shopware/db.base.yml
@@ -6,6 +6,7 @@ services:
           - mysql
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE:-shopware}
+      MYSQL_DISTRIBUTION: ${MYSQL_DISTRIBUTION:-mariadb}
       DB_AUTO_CREATE_DB: ${DB_AUTO_CREATE_DB:-shopware shopware_e2e shopware_test}
       DB_AUTO_CREATE_SH: |-
         if [ -n "$$MYSQL_USER" ] && [ -n "$$DB_AUTO_CREATE_DB" ]; then

--- a/environments/symfony/db.base.yml
+++ b/environments/symfony/db.base.yml
@@ -5,3 +5,4 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-symfony}
       - MYSQL_USER=${MYSQL_USER:-symfony}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-symfony}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}

--- a/environments/wordpress/db.base.yml
+++ b/environments/wordpress/db.base.yml
@@ -5,3 +5,4 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE:-wordpress}
       - MYSQL_USER=${MYSQL_USER:-wordpress}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-wordpress}
+      - MYSQL_DISTRIBUTION=${MYSQL_DISTRIBUTION:-mariadb}


### PR DESCRIPTION
# Issue

Trying to use MariaDB 12 in a Magento project caused the `db` (and `tmp-mysql`) service to fail with the following error:

```
2026-06-16 06:59:44+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:12.2.2+maria~ubu2404 started.
2026-06-16 06:59:44+00:00 [ERROR] [Entrypoint]: mariadbd failed while attempting to check config
        command was: mysqld --max_allowed_packet=1024M --explicit_defaults_for_timestamp=on --verbose --help
        /usr/local/bin/docker-entrypoint.sh: line 105: mysqld: command not found
```

This is due to MariaDB removing the mysql compatibility symlinks from their Docker images by default.

In addition the `warden db` commands do not work, for the same reason.

This was previously fixed in https://github.com/wardenenv/images/pull/50 by explicitly installing the MySQL compatibility packages if the MariaDB version was 11. However, that fix does not work when using 12 (12.3 is the suggested version for newer Magento releases).

We could fix the issue by always installing the compatibility packages (instead of just for MariaDB 11). This PR offers a different approach.

## Steps to reproduce

A Magento 2 environment with this configuration for the DB.
```.env
MYSQL_DISTRIBUTION=mariadb
MYSQL_DISTRIBUTION_VERSION=12.2
```

# Proposed Fix

## Services

For the DB services we can let the container entrypoint script to determine the correct command, instead of providing an explicit one.

Inspecting even older MySQL/MariaDB image entrypoint scripts

```sh
docker run --rm --entrypoint cat mysql:5.6 /usr/local/bin/docker-entrypoint.sh
```

show that they all (that I spot checked, at least) have this kind of snippet in the beginning of the main part of the script

```bash
_main() {
	# if command starts with an option, prepend mysqld
	if [ "${1:0:1}" = '-' ]; then
		set -- mysqld "$@"
	fi
```

So we do not actually need to provide the explicit command at all, but the container can decide what command to use.

## Commands

The `db` command has previously used the `MYSQL_DISTRIBUTION` environment variable for deciding which DB upgrade command to use.

This PR changes the command to do the same also for the client and dump commands.

### Using MYSQL_DISTRIBUTION

I don't know if the `warden db upgrade` command has ever worked, as the `MYSQL_` variables are read from the container's environment variables, and the `MYSQL_DISTRIBUTION` was never added there. In testing the command just failed for me.

This PR fixes that issue by including the MYSQL_DISTRIBUTION in the DB container environment, though that feels a tad hacky to be honest.