### PR TITLE
fix: add ruleSyntax v2 to varnish.base, magento2.base and magento2.gr…

### DIFF
--- a/environments/includes/varnish.base.yml
+++ b/environments/includes/varnish.base.yml
@@ -14,6 +14,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.priority=1
+      - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.ruleSyntax=v2
       - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.rule=
           HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-varnish.loadbalancer.server.port=80

--- a/environments/magento2/magento2.base.yml
+++ b/environments/magento2/magento2.base.yml
@@ -9,6 +9,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.priority=3
+      - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.ruleSyntax=v2
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.rule=
           (HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`))
             && (Path(`/livereload.js`) || Path(`/livereload`))

--- a/environments/magento2/magento2.graphql.base.yml
+++ b/environments/magento2/magento2.graphql.base.yml
@@ -24,6 +24,7 @@ services:
     extra_hosts: *extra_hosts
     labels:
       - traefik.enable=true
+      - traefik.http.routers.${WARDEN_ENV_NAME}-graphql.ruleSyntax=v2
       - traefik.http.routers.${WARDEN_ENV_NAME}-graphql.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-graphql.rule=(HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)) && Path(`/graphql`)
       - traefik.http.services.${WARDEN_ENV_NAME}-graphql.loadbalancer.server.port=9501


### PR DESCRIPTION


<!-- [BUG] Feel free to delete everything between the bug tags if not a bug -->
**Check List**
- [x] Is there an existing issue that covers this? ([933](https://github.com/wardenenv/warden/issues/933))
- [x] Is there an entry in the CHANGELOG.md file?

<!--
Delete below sections at will if there is already an issue open for this bug, and if it is described accurately in it.
-->

**Describe the bug**
Same as #933 and #934 but completed for varnish and all magento2 files.

**To Reproduce**
1. Add a project with subdomain (and varnish enabled)
2. Run `warden env up`
3. The subdomain (ie: app.example.com) will not work

**Expected behavior**
You will be able to access with subdomain to the service

**Additional context**
Add any other context about the problem here.
<!-- [/BUG] -->