### PR TITLE
Add support for overriding Warden .env variables with an .env.local file

### DIFF
--- a/utils/env.sh
+++ b/utils/env.sh
@@ -71,6 +71,12 @@ function loadEnvConfig () {
     loadEnvFile "${WARDEN_ENV_PATH}/.env" "TRAEFIK_"
     loadEnvFile "${WARDEN_ENV_PATH}/.env" "PHP_"
 
+    ## values in .env.local (typically git-ignored) override those in .env,
+    ## allowing per-clone settings such as a distinct WARDEN_ENV_NAME
+    loadEnvFile "${WARDEN_ENV_PATH}/.env.local" "WARDEN_"
+    loadEnvFile "${WARDEN_ENV_PATH}/.env.local" "TRAEFIK_"
+    loadEnvFile "${WARDEN_ENV_PATH}/.env.local" "PHP_"
+
     WARDEN_ENV_NAME="${WARDEN_ENV_NAME:-}"
     WARDEN_ENV_TYPE="${WARDEN_ENV_TYPE:-}"
     WARDEN_ENV_SUBT=""


### PR DESCRIPTION
Mentioned in #912 there is benefit to being able to override Warden variables in a manner that is non-committed. Notably if I have multiple copies of a codebase then I would need to change `WARDEN_ENV_NAME` and `TRAEFIK_DOMAIN` to prevent conflicts between them.

This PR reads the `.env.local` file after .env and overrides with any variables set. If per #912 we start using `.env.warden` then this could be similarly updated to be `.env.warden.local`

We could simply not commit the .env file, but it is helpful to keep multiple devs in sync with other changes to e.g. PHP versions there.