### PR TITLE
fix(sync): install Mutagen from current mutagen-io tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 **Bug Fixes:**
 * Add support to dynamically connect peered services based on enabled status ([#892](https://github.com/wardenenv/warden/issues/892) by @bap14, [#919](https://github.com/wardenenv/warden/issues/919) by @xinsodev)
 * Fix WARDEN_DOCKER_SOCK error running `warden sign-certificate` ([#907](https://github.com/wardenenv/warden/issues/907) by @bap14)
+* Install Mutagen from the current `mutagen-io/mutagen` tap instead of the deprecated `havoc-io` one, and report an actionable message when the automated install fails ([#944](https://github.com/wardenenv/warden/issues/944) by @lbajsarowicz)
 
 ## Version [0.16.0](https://github.com/wardenenv/warden/tree/0.16.0) (2026-02-12)
 

--- a/commands/env.cmd
+++ b/commands/env.cmd
@@ -247,9 +247,11 @@ fi
 
 if [[ ${WARDEN_MUTAGEN_ENABLE} -eq 1 ]] && [[ -f "${MUTAGEN_SYNC_FILE}" ]] # If we're using Mutagen
 then
-  MUTAGEN_VERSION=$(mutagen version)
+  ## mutagen may not be installed yet; "warden sync start" below installs it on demand
+  MUTAGEN_VERSION=$(mutagen version 2>/dev/null) || true
   CONNECTION_STATE_STRING='Connected state: Connected'
-  if [[ $((10#$(version "${MUTAGEN_VERSION}"))) -ge $((10#$(version '0.15.0'))) ]]; then
+  if [[ -n "${MUTAGEN_VERSION}" ]] \
+      && [[ $((10#$(version "${MUTAGEN_VERSION}"))) -ge $((10#$(version '0.15.0'))) ]]; then
     CONNECTION_STATE_STRING='Connected: Yes'
   fi
 

--- a/commands/sync.cmd
+++ b/commands/sync.cmd
@@ -21,7 +21,15 @@ fi
 ## attempt to install mutagen if not already present
 if ! which mutagen >/dev/null; then
   echo -e "\033[33mMutagen could not be found; attempting install via brew.\033[0m"
-  brew install havoc-io/mutagen/mutagen
+  brew install mutagen-io/mutagen/mutagen || true
+fi
+
+## instruct the user how to install mutagen when the automated install did not succeed
+if ! which mutagen >/dev/null; then
+  error "Mutagen could not be installed automatically."
+  >&2 printf "\nPlease install Mutagen manually and re-run this command:\n\n  brew trust mutagen-io/mutagen\n  brew install mutagen-io/mutagen/mutagen\n\n"
+  >&2 printf "If brew reports \"Formulae found in multiple taps\", untap the deprecated tap first:\n\n  brew untap havoc-io/mutagen\n\n"
+  exit 1
 fi
 
 ## verify mutagen version constraint
@@ -29,7 +37,7 @@ MUTAGEN_VERSION=$(mutagen version 2>/dev/null) || true
 MUTAGEN_REQUIRE=0.11.8
 if [[ $OSTYPE =~ ^darwin ]] && ! test $(version ${MUTAGEN_VERSION}) -ge $(version ${MUTAGEN_REQUIRE}); then
   error "Mutagen version ${MUTAGEN_REQUIRE} or greater is required (version ${MUTAGEN_VERSION} is installed)."
-  >&2 printf "\nPlease update Mutagen:\n\n  brew upgrade havoc-io/mutagen/mutagen\n\n"
+  >&2 printf "\nPlease update Mutagen:\n\n  brew upgrade mutagen-io/mutagen/mutagen\n\n"
   exit 1
 fi
 


### PR DESCRIPTION
Fixes #944

## Problem

On a fresh macOS host without Mutagen, `warden env up` dies like this:

```
==> Fetching downloads for: mutagen
✔︎ Formula mutagen (0.18.1)
Error: Formulae found in multiple taps:
       * havoc-io/mutagen/mutagen-beta
       * mutagen-io/mutagen/mutagen-beta

Please use the fully-qualified name (e.g. havoc-io/mutagen/mutagen-beta) to refer to a specific formula.
ERROR: Command `brew install havoc-io/mutagen/mutagen` at .../commands/sync.cmd:25 failed with exit code 1
.../commands/env.cmd: line 250: mutagen: command not found
```

`commands/sync.cmd` installs from `havoc-io/mutagen/mutagen` — the maintainer's old GitHub handle. That tap still resolves, so Warden silently taps a second copy of what is now `mutagen-io/mutagen`. With both taps present, brew has to resolve the *unqualified* name in the formula's own declaration:

```ruby
conflicts_with "mutagen-beta", :because => "both install `mutagen` binaries"
```

finds `mutagen-beta` in two taps, and aborts. Anyone who installed Mutagen the documented way (`mutagen-io` tap) therefore cannot let Warden auto-install it, and vice versa — Mutagen never lands.

Separately, `commands/env.cmd` called `mutagen version` with no check that the binary exists, so a failed install surfaced as a raw `mutagen: command not found` rather than anything the user can act on, and the version comparison after it silently evaluated the version as `0`.

## What this changes

* `commands/sync.cmd` installs and upgrades from `mutagen-io/mutagen/mutagen`.
* When the automated install does not produce a `mutagen` binary, Warden now stops with a message naming the exact commands to run, including the `brew untap havoc-io/mutagen` hint for hosts that already carry both taps.
* `commands/env.cmd` tolerates a missing Mutagen when probing the version, and leaves installation to `warden sync start` as before.

## Why this approach

The obvious alternative is to have `sync.cmd` run `brew trust mutagen-io/mutagen` itself so the install is fully unattended. Recent Homebrew refuses third-party formulae until the tap is trusted:

```
Error: Refusing to load formula mutagen-io/mutagen/mutagen-beta from untrusted tap mutagen-io/mutagen.
Run `brew trust --formula mutagen-io/mutagen/mutagen-beta` or `brew trust mutagen-io/mutagen` to trust it.
```

Trusting a tap grants standing permission to execute that tap's Ruby formulae on every later `brew` operation. Warden should not grant that on the user's behalf from inside a wrapper script, so this PR reports the command instead of running it. Guiding the user is the whole fix for that part; the install itself stays theirs to authorise.

### Security impact

`brew trust` is deliberately **not** invoked by Warden. The change only narrows what Warden does automatically: it no longer adds a second, deprecated tap to the user's Homebrew installation as a side effect of `warden env up`, and it never grants formula-execution trust. The suggested commands are printed for the user to review and run.

## Test plan

`bash -n commands/sync.cmd commands/env.cmd` — clean.

Guard path, with `mutagen` off `PATH` and a stub `brew` that fails, against a throwaway magento2 env:

```
Mutagen could not be found; attempting install via brew.
[stub brew] install mutagen-io/mutagen/mutagen
ERROR: Mutagen could not be installed automatically.

Please install Mutagen manually and re-run this command:

  brew trust mutagen-io/mutagen
  brew install mutagen-io/mutagen/mutagen

If brew reports "Formulae found in multiple taps", untap the deprecated tap first:

  brew untap havoc-io/mutagen
```

No `mutagen: command not found` anywhere in the output, and the tap name in the failure message is the current one.

Version-probe behaviour, both branches:

| `mutagen version` | `MUTAGEN_REQUIRE=0.11.8` | connection-state string |
| --- | --- | --- |
| `0.18.1` (installed) | satisfied | `Connected: Yes` |
| empty (not installed) | n/a, install is delegated | falls back to `Connected state: Connected`, no arithmetic error |

Verified on macOS 26.6.1 (Apple Silicon), Homebrew 6.0.16, Warden installed via brew, with Mutagen 0.18.1 installed from `mutagen-io/mutagen` after `brew untap havoc-io/mutagen`.
